### PR TITLE
Add Docker build cache to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -57,6 +57,8 @@ jobs:
         with:
           context: .
           file: ./Dockerfile
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Enhanced the Docker build step by adding caching mechanisms. This will optimize build times and make the CI/CD process more efficient by leveraging local build caches.